### PR TITLE
Remain cursor position and selection in real file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// get current selection
 		const targetSelection = selection.selections[0];
+		const targetScroll = vscode.window.activeTextEditor?.visibleRanges[0];
 
 		fs.realpath(filePath, async (err, realFilePath) => {
 			if (err) {
@@ -47,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 				const newEditor = vscode.window.activeTextEditor;
 				if (newEditor) {
 					newEditor.selection = targetSelection;
-					newEditor.revealRange(new vscode.Range(targetSelection.active, targetSelection.active), vscode.TextEditorRevealType.AtTop);
+					newEditor.revealRange(targetScroll ?? new vscode.Range(targetSelection.active, targetSelection.active), vscode.TextEditorRevealType.AtTop);
 				}
 
 				if (showFileInExplorer) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 				const newEditor = vscode.window.activeTextEditor;
 				if (newEditor) {
 					newEditor.selection = targetSelection;
+					newEditor.revealRange(new vscode.Range(targetSelection.active, targetSelection.active), vscode.TextEditorRevealType.AtTop);
 				}
 
 				if (showFileInExplorer) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,77 +2,77 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
-  let lastRealFilePath = '';
+	let lastRealFilePath = '';
 
-  const disposable = vscode.window.onDidChangeTextEditorSelection(async (selection) => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor || editor.document.uri.scheme !== 'file') return;
-    const filePath = editor.document.fileName!;
+	const disposable = vscode.window.onDidChangeTextEditorSelection(async (selection) => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor || editor.document.uri.scheme !== 'file') return;
+		const filePath = editor.document.fileName!;
 
-    // Skipping the file we just opened.
-    if (filePath === lastRealFilePath) return;
+		// Skipping the file we just opened.
+		if (filePath === lastRealFilePath) return;
 
-    // get current selection
-    const targetSelection = selection.selections[0];
+		// get current selection
+		const targetSelection = selection.selections[0];
 
-    fs.realpath(filePath, async (err, realFilePath) => {
-      if (err) {
-        // No need to burden user with error
-        return;
-      }
+		fs.realpath(filePath, async (err, realFilePath) => {
+			if (err) {
+				// No need to burden user with error
+				return;
+			}
 
-      // Not a symlink. No need to open real path.
-      if (filePath === realFilePath) return;
-      const symlinkFollowConfig = vscode.workspace.getConfiguration('symlink-follow');
-      const onlyFollowWithinWorkspace = symlinkFollowConfig.get('onlyFollowWithinWorkspace');
-      const realFileUri = vscode.Uri.file(realFilePath);
+			// Not a symlink. No need to open real path.
+			if (filePath === realFilePath) return;
+			const symlinkFollowConfig = vscode.workspace.getConfiguration('symlink-follow');
+			const onlyFollowWithinWorkspace = symlinkFollowConfig.get('onlyFollowWithinWorkspace');
+			const realFileUri = vscode.Uri.file(realFilePath);
 
-      if (onlyFollowWithinWorkspace) {
-        if (!vscode.workspace.getWorkspaceFolder(realFileUri)) {
-          // Our file isn't within any workspace folder and the user has asked
-          // to only follow symlink files within the workspace folder(s). Skip!
-          return;
-        }
-      }
+			if (onlyFollowWithinWorkspace) {
+				if (!vscode.workspace.getWorkspaceFolder(realFileUri)) {
+					// Our file isn't within any workspace folder and the user has asked
+					// to only follow symlink files within the workspace folder(s). Skip!
+					return;
+				}
+			}
 
-      const showFileInExplorer = symlinkFollowConfig.get('showFileInExplorerAfterSymlinkFollow');
-      const followSymlink = async () => {
-        lastRealFilePath = realFilePath;
-        if (vscode.window.activeTextEditor?.document.fileName == filePath) {
-          vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-        }
-        await vscode.commands.executeCommand('vscode.open', realFileUri);
+			const showFileInExplorer = symlinkFollowConfig.get('showFileInExplorerAfterSymlinkFollow');
+			const followSymlink = async () => {
+				lastRealFilePath = realFilePath;
+				if (vscode.window.activeTextEditor?.document.fileName == filePath) {
+					vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+				}
+				await vscode.commands.executeCommand('vscode.open', realFileUri);
 
-        // set selection
-        const newEditor = vscode.window.activeTextEditor;
-        if (newEditor) {
-          newEditor.selection = targetSelection;
-        }
+				// set selection
+				const newEditor = vscode.window.activeTextEditor;
+				if (newEditor) {
+					newEditor.selection = targetSelection;
+				}
 
-        if (showFileInExplorer) {
-          await vscode.commands.executeCommand('workbench.files.action.showActiveFileInExplorer');
-        }
-      };
+				if (showFileInExplorer) {
+					await vscode.commands.executeCommand('workbench.files.action.showActiveFileInExplorer');
+				}
+			};
 
-      const autoFollow = symlinkFollowConfig.get('autoFollow');
-      if (!autoFollow) {
-        const item = await vscode.window.showInformationMessage(
-          `${vscode.workspace.asRelativePath(filePath)} is a symlink`,
-          { modal: true, detail: `The real path is ${vscode.workspace.asRelativePath(realFilePath)}` },
-          'Follow Symlink',
-        );
+			const autoFollow = symlinkFollowConfig.get('autoFollow');
+			if (!autoFollow) {
+				const item = await vscode.window.showInformationMessage(
+					`${vscode.workspace.asRelativePath(filePath)} is a symlink`,
+					{ modal: true, detail: `The real path is ${vscode.workspace.asRelativePath(realFilePath)}` },
+					'Follow Symlink',
+				);
 
-        if (item) {
-          followSymlink();
-        }
-      } else {
-        followSymlink();
-      }
-    });
+				if (item) {
+					followSymlink();
+				}
+			} else {
+				followSymlink();
+			}
+		});
 
-  });
+	});
 
-  context.subscriptions.push(disposable);
+	context.subscriptions.push(disposable);
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,6 @@ export function activate(context: vscode.ExtensionContext) {
 		// Skipping the file we just opened.
 		if (filePath === lastRealFilePath) return;
 
-		// get current selection
-		const targetSelection = selection.selections[0];
-		const targetScroll = vscode.window.activeTextEditor?.visibleRanges[0];
-
 		fs.realpath(filePath, async (err, realFilePath) => {
 			if (err) {
 				// No need to burden user with error
@@ -36,6 +32,10 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 			}
 
+			// get current selection and scroll position
+			const targetSelection = selection.selections[0];
+			const targetScrollTop = editor.visibleRanges[0]?.start ?? targetSelection.active;
+
 			const showFileInExplorer = symlinkFollowConfig.get('showFileInExplorerAfterSymlinkFollow');
 			const followSymlink = async () => {
 				lastRealFilePath = realFilePath;
@@ -44,11 +44,11 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 				await vscode.commands.executeCommand('vscode.open', realFileUri);
 
-				// set selection
+				// apply selection and scroll position
 				const newEditor = vscode.window.activeTextEditor;
 				if (newEditor) {
 					newEditor.selection = targetSelection;
-					newEditor.revealRange(targetScroll ?? new vscode.Range(targetSelection.active, targetSelection.active), vscode.TextEditorRevealType.AtTop);
+					newEditor.revealRange(new vscode.Range(targetScrollTop, targetScrollTop), vscode.TextEditorRevealType.AtTop);
 				}
 
 				if (showFileInExplorer) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,66 +2,77 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
-	let lastRealFilePath = '';
+  let lastRealFilePath = '';
 
-	const disposable = vscode.window.onDidChangeActiveTextEditor(async ed => {
-		if (!ed || ed.document.uri.scheme !== 'file') return;
-		const filePath = ed.document.fileName!;
+  const disposable = vscode.window.onDidChangeTextEditorSelection(async (selection) => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.uri.scheme !== 'file') return;
+    const filePath = editor.document.fileName!;
 
-		// Skipping the file we just opened.
-		if (filePath === lastRealFilePath) return;
+    // Skipping the file we just opened.
+    if (filePath === lastRealFilePath) return;
 
-		fs.realpath(filePath, async (err, realFilePath) => {
-			if (err) {
-				// No need to burden user with error
-				return;
-			}
+    // get current selection
+    const targetSelection = selection.selections[0];
 
-			// Not a symlink. No need to open real path.
-			if (filePath === realFilePath) return;
-			const symlinkFollowConfig = vscode.workspace.getConfiguration('symlink-follow');
-			const onlyFollowWithinWorkspace = symlinkFollowConfig.get('onlyFollowWithinWorkspace');
-			const realFileUri = vscode.Uri.file(realFilePath);
+    fs.realpath(filePath, async (err, realFilePath) => {
+      if (err) {
+        // No need to burden user with error
+        return;
+      }
 
-			if (onlyFollowWithinWorkspace) {
-				if (!vscode.workspace.getWorkspaceFolder(realFileUri)) {
-					// Our file isn't within any workspace folder and the user has asked
-					// to only follow symlink files within the workspace folder(s). Skip!
-					return;
-				}
-			}
+      // Not a symlink. No need to open real path.
+      if (filePath === realFilePath) return;
+      const symlinkFollowConfig = vscode.workspace.getConfiguration('symlink-follow');
+      const onlyFollowWithinWorkspace = symlinkFollowConfig.get('onlyFollowWithinWorkspace');
+      const realFileUri = vscode.Uri.file(realFilePath);
 
-			const showFileInExplorer = symlinkFollowConfig.get('showFileInExplorerAfterSymlinkFollow');
-			const followSymlink = async () => {
-				lastRealFilePath = realFilePath;
-				if (vscode.window.activeTextEditor?.document.fileName == filePath) {
-					vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-				}
-				await vscode.commands.executeCommand('vscode.open', realFileUri);
-				if (showFileInExplorer) {
-					await vscode.commands.executeCommand('workbench.files.action.showActiveFileInExplorer');
-				}
-			};
+      if (onlyFollowWithinWorkspace) {
+        if (!vscode.workspace.getWorkspaceFolder(realFileUri)) {
+          // Our file isn't within any workspace folder and the user has asked
+          // to only follow symlink files within the workspace folder(s). Skip!
+          return;
+        }
+      }
 
-			const autoFollow = symlinkFollowConfig.get('autoFollow');
-			if (!autoFollow) {
-				const item = await vscode.window.showInformationMessage(
-					`${vscode.workspace.asRelativePath(filePath)} is a symlink`,
-					{ modal: true, detail: `The real path is ${vscode.workspace.asRelativePath(realFilePath)}` },
-					'Follow Symlink',
-				);
+      const showFileInExplorer = symlinkFollowConfig.get('showFileInExplorerAfterSymlinkFollow');
+      const followSymlink = async () => {
+        lastRealFilePath = realFilePath;
+        if (vscode.window.activeTextEditor?.document.fileName == filePath) {
+          vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        }
+        await vscode.commands.executeCommand('vscode.open', realFileUri);
 
-				if (item) {
-					followSymlink();
-				}
-			} else {
-				followSymlink();
-			}
-		});
+        // set selection
+        const newEditor = vscode.window.activeTextEditor;
+        if (newEditor) {
+          newEditor.selection = targetSelection;
+        }
 
-	});
+        if (showFileInExplorer) {
+          await vscode.commands.executeCommand('workbench.files.action.showActiveFileInExplorer');
+        }
+      };
 
-	context.subscriptions.push(disposable);
+      const autoFollow = symlinkFollowConfig.get('autoFollow');
+      if (!autoFollow) {
+        const item = await vscode.window.showInformationMessage(
+          `${vscode.workspace.asRelativePath(filePath)} is a symlink`,
+          { modal: true, detail: `The real path is ${vscode.workspace.asRelativePath(realFilePath)}` },
+          'Follow Symlink',
+        );
+
+        if (item) {
+          followSymlink();
+        }
+      } else {
+        followSymlink();
+      }
+    });
+
+  });
+
+  context.subscriptions.push(disposable);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
#### Current problem
Currently, if a user `Ctrl + Click`'s a symbol to go to its definition and the definition is a linked file, the real file will open but at position `0,0`.

#### Fix
With this change, the position will be saved in the linked file and applied again in the real file (including scroll position).
Fixes #2 

#### Additional info
For this to work, it was necessary to change the `onDidChangeActiveTextEditor` to `onDidChangeTextEditorSelection`, because the cursor selection is not yet set when `onDidChangeActiveTextEditor` is called.