### PR TITLE
Preserve file position when following symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.0.1]
+
+- Fixed file position propagating when following symlink
+
 ## [1.0.0]
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "symlink-follow",
 	"displayName": "Symlink Follow",
 	"description": "Follow symlink when opening files in VSCode",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"publisher": "zaucy",
 	"repository": "https://github.com/zaucy/vscode-symlink-follow",
 	"engines": {


### PR DESCRIPTION
Works as expected when symlink is opened by using "Go to definition" or something similar. If you directly open symlink via "Open file", the last position in symlink will be applied to real file, not the last position in real file itself.

Example of problem:
1. You press "Go to definition" which opens symlink aa.py -> real file a.py at line 5.
2. Move to line 10 in a.py
3. Open aa.py via "open file" dialog - it will open file a.py and jump to line 5 because that's the last known to VSCode position in aa.py

I don't think it needs immediate fix, and it is not obvious how to do it, I did not find a way to get "last position per file" info from VSCode. One possible solution is to save file positions ourselves in a map, but that seems kind of excessive for such a minor problem.

Fixes #2, #3